### PR TITLE
French: use translated part

### DIFF
--- a/OS/LD_PRELOAD/main_FR.tex
+++ b/OS/LD_PRELOAD/main_FR.tex
@@ -32,8 +32,8 @@ $ cat /proc/uptime
 416690.91 415152.03
 \end{lstlisting}
 
-Ce que l'on peut apprendre depuis Wikipedia
-\footnote{\href{http://go.yurichev.com/17043}{wikipedia}}:
+Ce que l'on peut apprendre depuis Wikipédia
+\footnote{\href{http://go.yurichev.com/17043}{Wikipédia}}:
 
 \begin{framed}
 \begin{quotation}

--- a/OS/PE/main_FR.tex
+++ b/OS/PE/main_FR.tex
@@ -88,7 +88,7 @@ de liens}.
 \myindex{ASLR}
 
 Il y a une autre raison de charger les modules a des adresses de base variées, aléatoires
-dans ce cas. C'est l'\ac{ASLR}\footnote{\href{http://go.yurichev.com/17140}{wikipedia}}.
+dans ce cas. C'est l'\ac{ASLR}\footnote{\href{http://go.yurichev.com/17140}{Wikipédia}}.
 
 \myindex{Shellcode}
 
@@ -126,7 +126,7 @@ Un fichier PE indique aussi la version de Windows minimale requise pour pouvoir 
 chargé.
 
 La table des numéros de version stockés dans un fichier PE et les codes de Windows
-correspondants est ici\footnote{\href{http://go.yurichev.com/17044}{wikipedia}}.
+correspondants est ici\footnote{\href{http://go.yurichev.com/17044}{Wikipédia}}.
 
 \myindex{Windows!Windows NT4}
 \myindex{Windows!Windows 2000}

--- a/OS/SEH/1/main_FR.tex
+++ b/OS/SEH/1/main_FR.tex
@@ -50,7 +50,7 @@ des informations techniques qui seront envoyées aux développeurs de Microsoft.
 \end{figure}
 
 Historiquement, cette chaîne de gestionnaires était connue sous l'appelation Dr. Watson
-\footnote{\href{http://go.yurichev.com/17046}{wikipedia}}.
+\footnote{\href{http://go.yurichev.com/17046}{Wikipédia}}.
 
 Certains développeurs ont eu l'idée d'écrire leur propre gestionnaire d'exceptions pour recevoir 
 les informations relatives au crash.

--- a/parts.tex
+++ b/parts.tex
@@ -28,6 +28,7 @@
 \EN{\input{community_EN}}
 \RU{\input{community_RU}}
 \DE{\input{community_DE}}
+\FR{\input{community_FR}}
 
 \input{afterword}
 

--- a/patterns/01_helloworld/MSVC_x86_FR.tex
+++ b/patterns/01_helloworld/MSVC_x86_FR.tex
@@ -104,7 +104,7 @@ Dans le code généré cela est implémenté par l'instruction \INS{XOR EAX, EAX
 
 \myindex{x86!\Instructions!MOV}
 
-\XOR est en fait un simple \q{OU exclusif (eXclusive OR}\footnote{\href{http://go.yurichev.com/17118}{wikipedia}} mais
+\XOR est en fait un simple \q{OU exclusif (eXclusive OR}\footnote{\href{http://go.yurichev.com/17118}{Wikipédia}} mais
 les compilateurs l'utilisent souvent à la place de \INS{MOV EAX, 0}---à nouveau parce que l'opcode est légèrement plus
 court (2 octets pour \XOR contre 5 pour \MOV).
 

--- a/patterns/04_scanf/3_checking_retval/x86_FR.tex
+++ b/patterns/04_scanf/3_checking_retval/x86_FR.tex
@@ -34,7 +34,7 @@ Il passe le contrôle au point après le second \printf et juste avant l'instruc
 \myindex{x86!\Registers!\Flags}
 Donc, on peut dire que comparer une valeur avec une autre est \IT{usuellement} implémenté
 par la paire d'instructions \CMP/\Jcc, oú \IT{cc} est un \IT{code de condition}.
-\CMP compare deux valeurs et met les flags\footnote{flags x86, voir aussi: \href{http://go.yurichev.com/17120}{wikipedia}.}
+\CMP compare deux valeurs et met les flags\footnote{flags x86, voir aussi: \href{http://go.yurichev.com/17120}{Wikipédia}.}
 du processeur.
 \Jcc vérifie ces flags et décide de passer le contrôle à l'adresse spécifiée ou non.
 

--- a/patterns/05_passing_arguments/ARM/no_keil_ARM_FR.tex
+++ b/patterns/05_passing_arguments/ARM/no_keil_ARM_FR.tex
@@ -34,11 +34,11 @@ le résultat dans le registre zéro (\Reg{0}), par lequel, d'après le standard,
 fonctions retournent leur résultat.
 
 \myindex{Fused multiply–add}
-\footnote{\href{http://go.yurichev.com/17103}{wikipedia}}.
+\footnote{\href{http://go.yurichev.com/17103}{Wikipédia}}.
 La multiplication et l'addition en une fois (\IT{Fused multiply–add})
 est une instruction très utile. A propos, il n'y avait pas une telle instruction en
 x86 avant les instructions FMA apparues en SIMD
-\footnote{\href{http://go.yurichev.com/17103}{wikipedia}}.
+\footnote{\href{http://go.yurichev.com/17103}{Wikipédia}}.
 
 La toute première instruction \TT{MOV R3, R0}, est, apparement, redondante (car
 une seule instruction \TT{MLA} pourrait être utilisée à la place ici).

--- a/patterns/08_switch/1_few/x86_FR.tex
+++ b/patterns/08_switch/1_few/x86_FR.tex
@@ -90,7 +90,7 @@ l'instruction \RET qui POPs \ac{RA} de la pile et l'exécution est renvoyée non
 fonction \ttf.
 
 \myindex{\CStandardLibrary!longjmp()}
-\newcommand{\URLSJ}{\href{http://go.yurichev.com/17121}{wikipedia}}
+\newcommand{\URLSJ}{\href{http://go.yurichev.com/17121}{Wikipédia}}
 
 % TODO \myref{}
 Tout ceci est possible car \printf est appeléi, dans tous les cas, tout à la fin

--- a/patterns/08_switch/2_lot/lot_x86_FR.tex
+++ b/patterns/08_switch/2_lot/lot_x86_FR.tex
@@ -29,7 +29,7 @@ le label \TT{\$LN4@f} est stocké.
 Cette table est quelquefois appelée \IT{jumptable} (table de saut) ou \IT{branch table}
 (table de branchement)\footnote{L'ensemble de la méthode était appelé \IT{computed
 GOTO} (GOTO calculés) dans les premières versions de ForTran:
-\href{http://go.yurichev.com/17122}{wikipedia}.
+\href{http://go.yurichev.com/17122}{Wikipédia}.
 Pas très pertinent de nos jours, mais quel terme!}.
 
 Le \printf correspondant est appelé avec l'argument \TT{'two'}.\\

--- a/patterns/12_FPU/1_simple/ARM/main_FR.tex
+++ b/patterns/12_FPU/1_simple/ARM/main_FR.tex
@@ -38,7 +38,7 @@ pour des opérations SIMD (NEON) et cela va être montré bientôt.
 
 Les arguments sont passés à la fonction de manière classique, via les registres-R,
 toutefois, chaque nombres en double précision a une taille de 64 bits, donc deux
-registres-R sont nécessaire pour passer chacun d'entre eux.
+registres-R sont nécessaires pour passer chacun d'entre eux.
 
 \INS{VMOV D17, R0, R1} au début, combine les deux valeurs 32-bit de \Reg{0} et \Reg{1}
 en une valeur 64-bit et la sauve dans \GTT{D17}.

--- a/patterns/12_FPU/3_comparison/x86/MSVC/main_FR.tex
+++ b/patterns/12_FPU/3_comparison/x86/MSVC/main_FR.tex
@@ -67,7 +67,7 @@ remarquable.
 Ce flag est mis à 1 si le nombre de un dans le résultat du dernier calcul est pair,
 et à 0 s'il est impair.
 
-Regardons sur Wikipedia\footnote{\href{http://go.yurichev.com/17131}{wikipedia.org/wiki/Parity\_flag}}:
+Regardons sur Wikipédia\footnote{\href{http://go.yurichev.com/17131}{wikipedia.org/wiki/Parity\_flag}}:
 
 \begin{framed}
 \begin{quotation}
@@ -81,7 +81,7 @@ Le flag C2 est mis lorsque e.g. des valeurs en virgule flottantes incomparable
 \end{quotation}
 \end{framed}
 
-Comme indiqué dans Wikipedia, le flag de parité est parfois utilisé dans du code
+Comme indiqué dans Wikipédia, le flag de parité est parfois utilisé dans du code
 FPU, voyons comment.
 
 \myindex{x86!\Instructions!JP}

--- a/patterns/12_FPU/main_FR.tex
+++ b/patterns/12_FPU/main_FR.tex
@@ -90,7 +90,7 @@ Le type \Tfloat nécessite le même nombre de bits que le type \Tint dans les en
 \subsection{Quelques constantes}
 
 Il est facile de trouver la représentation de certaines constantes pour des nombres
-encodés au format IEEE 754 sur Wikipedia.
+encodés au format IEEE 754 sur Wikipédia.
 Il est intéressant de savoir que 0,0 en IEEE 754 est représenté par 32 bits à zéro
 (pour la simple précision) ou 64 bits à zéro (pour la double).
 Donc pour mettre une variable flottante à 0,0 dans un registre ou en mémoire, on
@@ -133,7 +133,7 @@ Il y a une hypothèse que c'est probablement dû à des raisons historiques---le
 IBM de carte perforée peut encoder 12 lignes de 80 bits.
 La résolution en mode texte de $80\cdot 25$ était aussi très populaire dans le passé.
 
-Il y a une autre explication sur Wikipedia: \url{https://en.wikipedia.org/wiki/Extended_precision}.
+Il y a une autre explication sur Wikipédia: \url{https://en.wikipedia.org/wiki/Extended_precision}.
 
 Si vous en savez plus, s'il vous plait envoyez un email à l'auteur: \EMAIL{}.
 

--- a/patterns/13_arrays/2_BO/writing_FR.tex
+++ b/patterns/13_arrays/2_BO/writing_FR.tex
@@ -93,7 +93,7 @@ une exception est levée.
 
 \myindex{\BufferOverflow}
 
-Bienvenu! Ca s'appelle un \IT{buffer overflow (débordement de tampon)}\footnote{\href{http://go.yurichev.com/17132}{wikipedia}}.
+Bienvenu! Ca s'appelle un \IT{buffer overflow (débordement de tampon)}\footnote{\href{http://go.yurichev.com/17132}{Wikipédia}}.
 
 Remplacez la tableau de \Tint avec une chaîne (\Tchar array), créez délibérément
 une longue chaîne et passez-là au programme, à la fonction, qui ne teste pas la longueur

--- a/patterns/15_structs/6_bitfields/cpuid/main_FR.tex
+++ b/patterns/15_structs/6_bitfields/cpuid/main_FR.tex
@@ -7,7 +7,7 @@ représenter une variable \Tbool. Bien entendu, c'est au détriment de la vitess
 % another use of this is to parse binary protocols/packets, for example
 % the definition of struct iphdr in include/linux/ip.h
 
-\newcommand{\FNCPUID}{\footnote{\href{http://go.yurichev.com/17069}{wikipedia}}}
+\newcommand{\FNCPUID}{\footnote{\href{http://go.yurichev.com/17069}{Wikipédia}}}
 
 \myindex{x86!\Instructions!CPUID}
 \label{cpuid}


### PR DESCRIPTION
The community_FR part was translated but not used in the book.