### PR TITLE
Corrections and update

### DIFF
--- a/acronyms.tex
+++ b/acronyms.tex
@@ -289,4 +289,7 @@
 \acro{URL}{Uniform Resource Locator}
 \acro{ISP}{Internet Service Provider}
 \acro{IV}{Initialization Vector}
+\acro{RSA}{Rivest Shamir Adleman}
+\acro{CPRNG}{Cryptographically secure PseudoRandom Number Generator}
+\acro{GiB}{Gibibyte}
 \end{acronym}

--- a/acronyms.tex
+++ b/acronyms.tex
@@ -133,11 +133,11 @@
 	\acro{OS}[OS]{Système d'exploitation (Operating System)}
 	\acro{FAQ}{Foire Aux Questions}
 	\acro{OOP}[POO]{Programmation orientée objet}
-	\acro{PL}[LP]{Language de programmation}
+	\acro{PL}[LP]{Langage de programmation}
 	\acro{PRNG}{Nombre généré pseudo-aléatoirement}
 	\acro{ROM}{Mémoire morte}
 	\acro{ALU}[UAL]{Unité arithmétique et logique}
-	\acro{PID}{ID d'un programme/processus}
+	\acro{PID}{ID d'un processus}
 	\acro{LF}{Line feed (10 ou '\textbackslash{}n' en \CCpp)}
 	\acro{CR}{Carriage return (13 ou '\textbackslash{}r' en \CCpp)}
 	\acro{LIFO}{Dernier entré, premier sorti}

--- a/glossary.tex
+++ b/glossary.tex
@@ -233,7 +233,7 @@
   	\RU{не число: специальные случаи чисел с плавающей запятой, 
   	обычно сигнализирующие об ошибках}\EN{not a number: 
   	a special cases for floating point numbers, usually signaling about errors}\ESph{}\PTBRph{}\DEph{}\PLph{}\ITAph{}
-    \FR{pas un nombre: nu cas particulier pour les nombres flottants, signifiant généralement une erreur}
+    \FR{pas un nombre: un cas particulier pour les nombres à virgule flottante, indiquant généralement une erreur}
     \JPN{非数：float型の数の特殊なケースで、エラーが通知される}
   }
 }


### PR DESCRIPTION
Minors corrections of French parts.
Add missing acronyms. Maybe links to Wikipédia will be a good point.