### PR TITLE
French: typo, missing translation

### DIFF
--- a/OS/SEH/main.tex
+++ b/OS/SEH/main.tex
@@ -42,7 +42,7 @@
 \EN{\input{OS/SEH/2/main_EN}}
 \RU{\input{OS/SEH/2/main_RU}}
 \DE{\input{OS/SEH/2/main_DE}}
-\DE{\input{OS/SEH/2/main_FR}}
+\FR{\input{OS/SEH/2/main_FR}}
 
 \EN{\input{OS/SEH/3/main_EN}}
 \RU{\input{OS/SEH/3/main_RU}}
@@ -52,7 +52,8 @@
 \subsubsection{
 \RU{Больше о}
 \EN{Read more about}
-\DE{Mehr über} SEH
+\DE{Mehr über}
+\FR{En lire plus sur} SEH
 }
 
 \PietrekSEH, \IgorSkochinsky.


### PR DESCRIPTION
A translated file was not included.