### PR TITLE
French: translation, update

### DIFF
--- a/advanced/600_memmove/main_FR.tex
+++ b/advanced/600_memmove/main_FR.tex
@@ -1,0 +1,92 @@
+\mysection{memmove() et memcpy()}
+\label{memmove_and_DF}
+\myindex{\CStandardLibrary!memmove()}
+\myindex{\CStandardLibrary!memcpy()}
+
+La différence entre ces deux fonctions standards est que \IT{memcpy()} copie aveuglément
+un bloc à un autre endroit, alors que \IT{memmove()} gère correctement les blocs
+qui se recouvrent.
+Par exemple, si vous voulez déplacer une chaîne de deux octets en avant:
+
+% TODO TikZ
+\begin{lstlisting}
+`|.|.|h|e|l|l|o|...` -> `|h|e|l|l|o|...`
+\end{lstlisting}
+
+\IT{memcpy()} qui copie des mots de 32-bit ou de 64-bit à la fois, ou même \ac{SIMD},
+va manifestement échouer ici, une routine de copie octet par octet doit être utilisée
+à la place.
+
+Maintenant un exemple encore plus avancé, insérer deux octets au début d'une chaîne:
+
+\begin{lstlisting}
+`|h|e|l|l|o|...` -> `|.|.|h|e|l|l|o|...`
+\end{lstlisting}
+
+Maintenant, même une copie octet par octet va échouer, car vous devez copier en partant
+de la fin.
+
+\myindex{x86!\Registers!DF}
+C'est un cas rare où le flag x86 \TT{DF} doit être mis avant l'instruction \INS{REP MOVSB}:
+\TT{DF} défini la direction, et maintenant, nous devons déplacer en arrière.
+
+La routine \IT{memmove()} typique fonctionne comme ceci:
+1) si la source est avant la destination, copier en avant;
+2) si la source est après la destination, copier en arrière.
+
+\myindex{uClibc}
+Ceci est la fonction \IT{memmove()} de uClibc:
+
+\begin{lstlisting}[style=customc]
+void *memmove(void *dest, const void *src, size_t n)
+{
+	int eax, ecx, esi, edi;
+	__asm__ __volatile__(
+		"	movl	%%eax, %%edi\n"
+		"	cmpl	%%esi, %%eax\n"
+		"	je	2f\n" /* (optional) src == dest -> NOP */
+		"	jb	1f\n" /* src > dest -> simple copy */
+		"	leal	-1(%%esi,%%ecx), %%esi\n"
+		"	leal	-1(%%eax,%%ecx), %%edi\n"
+		"	std\n"
+		"1:	rep; movsb\n"
+		"	cld\n"
+		"2:\n"
+		: "=&c" (ecx), "=&S" (esi), "=&a" (eax), "=&D" (edi)
+		: "0" (n), "1" (src), "2" (dest)
+		: "memory"
+	);
+	return (void*)eax;
+}
+\end{lstlisting}
+
+Dans le premier cas, \INS{REP MOVSB} est appelée avec le flag \TT{DF} à zéro.
+Dans le second, \TT{DF} est mis, puis remis à zéro.
+
+Un algorithme plus complexe contient la logique suivante:
+
+\q{Si la différence entre la \IT{source} et la \IT{destination} est plus grande que
+la largeur d'un \glslink{word}{mot}, copier en utilisant des mots plutôt que des octets,
+et utiliser une copie octet par octet pour copier les parties non alignées.}
+
+\myindex{Glibc}
+Voici comment ça se passe dans la partie C non optimisée de la Glibc 2.24.
+
+Compte tenu de cela, \IT{memmove()} peut être plus lente que \IT{memcpy()}.
+Mais certains, Linus Torvalds inclus, argumentent\footnote{\url{https://bugzilla.redhat.com/show_bug.cgi?id=638477\#c132}}
+que \IT{memcpy()} devrait être un alias (ou synonyme) de \IT{memmove()}, et cette
+dernière fonction devrait juste tester au début, si les buffers se recouvrent ou
+non, et ensuite se comporter comme \IT{memcpy()} ou \IT{memmove()}.
+De nos jours, le test de recouvrement de buffers est peu coûteux, après tout.
+
+\subsection{Stratagème anti-debugging}
+
+J'ai entendu parler de stratagème anti-debugging où tout ce que vous devez faire pour
+crasher le processus est de mettre \TT{DF}: le prochain appel à \IT{memcpy()} va
+conduire au crash, car il copiera en arrière.
+Mais je ne peux pas tester ceci: il semble que toutes les routines de copie de mémoire
+mettent \TT{DF} à 1/0 comme elles le veulent.
+D'un autre côté, \IT{memmove()} de uClibc que j'ai déjà cité ici, ne remet pas explicitement
+\TT{DF} à zéro (assume-t-elle que \TT{DF} est toujours à zéro?), donc ça peut vraiment
+planter.
+

--- a/advanced/main.tex
+++ b/advanced/main.tex
@@ -70,7 +70,7 @@
 
 \EN{\input{advanced/550_more_structs/main_EN}}\RU{\input{advanced/550_more_structs/main_RU}}
 
-\EN{\input{advanced/600_memmove/main_EN}}\RU{\input{advanced/600_memmove/main_RU}}
+\EN{\input{advanced/600_memmove/main_EN}}\RU{\input{advanced/600_memmove/main_RU}}\FR{\input{advanced/600_memmove/main_FR}}
 
 \EN{\input{advanced/625_setjmp/main_EN}}\RU{\input{advanced/625_setjmp/main_RU}}\FR{\input{advanced/625_setjmp/main_FR}}
 

--- a/afterword_FR.tex
+++ b/afterword_FR.tex
@@ -1,5 +1,5 @@
-﻿\part*{Epilogue}
-\addcontentsline{toc}{part}{Epilogue}
+﻿\part*{Épilogue}
+\addcontentsline{toc}{part}{Épilogue}
 
 \mysection{Des questions ?}
 
@@ -20,7 +20,7 @@ dans le code source :
 \href{http://go.yurichev.com/17089}{GitHub}.
 
 N'hésitez surtout pas à m'envoyer la moindre erreur que vous pourriez trouver, aussi
-petite qu'elle soit, même si vous n'êtes pas certain que ce soit une erreur.
+petite soit-elle, même si vous n'êtes pas certain que ce soit une erreur.
 J'écris pour les débutants après tout, il est donc crucial pour mon travail d'avoir
 les retours de débutants.
 

--- a/community_FR.tex
+++ b/community_FR.tex
@@ -1,6 +1,6 @@
 \chapter{Communautés}
 
-Il existe deux excellents subreddits liés à la \ac{RE} (rétro-ingénierie) sur reddit.com :
+Il existe deux excellents subreddits liés à la \ac{RE} (rétro-ingénierie) sur reddit.com :\\
 \href{http://go.yurichev.com/17027}{reddit.com/r/ReverseEngineering/} et
 \href{http://go.yurichev.com/17028}{reddit.com/r/remath}
 (en lien avec la liaison de la \ac{RE} et des mathématiques).
@@ -9,6 +9,6 @@ Il y a également une section sur l'\ac{RE} sur le site Stack Exchange :
 
 \par \href{http://go.yurichev.com/17029}{reverseengineering.stackexchange.com}.
 
-Sur IRC, il y a un channel dédié au \#\#\'reverse\' sur
+Sur IRC, il y a un channel \#\#re sur
 FreeNode\footnote{\href{http://go.yurichev.com/17030}{freenode.net}}.
 

--- a/other/8086mm_FR.tex
+++ b/other/8086mm_FR.tex
@@ -22,7 +22,7 @@ Et probablement pour une raison de portage de vieux logiciels\footnote{Je ne sui
 pas sûr à 100\% de ceci}, le 8086 peut supporter plusieurs fenêtres de 64KB simultanément,
 situées dans l'espace d'adresse de 1MB.
 
-C'est une sorte de virualisation de niveau jouet.
+C'est une sorte de virtualisation de niveau jouet.
 \myindex{x86!\Registers!CS}
 \myindex{x86!\Registers!DS}
 \myindex{x86!\Registers!ES}
@@ -53,7 +53,7 @@ L'adresse réelle sur le bus d'adresse de 20-bit, toutefois, sera dans l'interva
 Le programme peut contenir des adresses codées en dur comme 0x1234, mais l'\ac{OS}
 peut avoir besoin de le charger à une adresse arbitraire, donc il recalcule les valeurs
 du registre de segment de façon à ce que le programme n'ait pas à se soucier de
-l'endroit oũ il est placé dans la RAM.
+l'endroit où il est placé dans la RAM.
 
 Donc, tout pointeur dans le vieil environnement MS-DOS consistait en fait en un segment
 d'adresse et une adresse dans ce segment, i.e., deux valeurs 16-bit. 20-bit étaient

--- a/other/anomaly2_FR.tex
+++ b/other/anomaly2_FR.tex
@@ -16,11 +16,11 @@ Je viens juste de trouver celui-ci dans un vieux fragment de code :
 \end{lstlisting}
 
 \myindex{x86!\Instructions!FXCH}
-La première instruction \INS{FXCH} interverti les valeurs de \TT{ST(0)} et \TT{ST(1)}. La seconde 
+La première instruction \INS{FXCH} intervertit les valeurs de \TT{ST(0)} et \TT{ST(1)}. La seconde
 effectue la même opération. Combinées, elles ne produisent donc aucun effet.
-Cet extrait provient d'un programme qui utilise la librairie MFC42.dll, il a donc du être compilé 
+Cet extrait provient d'un programme qui utilise la bibliothèque MFC42.dll, il a donc dû être compilé
 avec MSVC 6.0 ou 5.0 ou peut-être même MSVC 4.2 qui date des années 90.
 
-Cette paire d'instruction ne produit aucun effet, ce qui expliquerait qu'elle n'ait pas été détectée 
+Cette paire d'instructions ne produit aucun effet, ce qui expliquerait qu'elle n'ait pas été détectée
 lors des tests du compilateur MSVC. Ou bien j'ai loupé quelque chose ...
 

--- a/other/args_stat_FR.tex
+++ b/other/args_stat_FR.tex
@@ -30,5 +30,5 @@ désassemblé).
 \end{figure}
 
 Ces nombres dépendent beaucoup du style de programmation et peuvent s'avérer très différents pour 
-d'autres produits logiciels.
+d'autres logiciels.
 

--- a/other/compiler_intrinsic_FR.tex
+++ b/other/compiler_intrinsic_FR.tex
@@ -5,20 +5,20 @@
 \myindex{x86!\Instructions!ROL}
 \myindex{x86!\Instructions!ROR}
 
-Les fonctions intrinsèques sont spécifiques à chaque compilateur. Ce ne sont pas des fonctions que 
-vous pouvez retrouver dans une librairie.
-Le compilateur génère une séquence spécifique de code machine lorsqu'il rencontre la fonction 
-intrinsèque. Le plus souvent, il s'agit d'une pseudo fonction qui correspond à une instruction d'une 
-\ac{CPU} particulière. \\
+Les fonctions intrinsèques sont spécifiques à chaque compilateur. Ce ne sont pas des fonctions que
+vous pouvez retrouver dans une bibliothèque.
+Le compilateur génère une séquence spécifique de code machine lorsqu'il rencontre la fonction
+intrinsèque. Le plus souvent, il s'agit d'une pseudo fonction qui correspond à une instruction d'un
+\ac{CPU} particulier.\\
 \\
-Par exemple, il n'existe pas d'opérateur de décalage cyclique dans les langages \CCpp. La plupart 
+Par exemple, il n'existe pas d'opérateur de décalage cyclique dans les langages \CCpp. La plupart
 des \ac{CPU}s supportent cependant des instructions de ce type.
 Pour faciliter la vie des programmeurs, le compilateur MSVC propose de telles pseudo fonctions
 \IT{\_rotl()} and \IT{\_rotr()}\FNMSDNROTxURL{}
 qui sont directement traduites par le compilateur vers les instructions x86 ROL/ROR. \\
 \\
-Les fonctions intrinsèques qui permettent de générer des instructions SSE sont un autre exemple.
+Les fonctions intrinsèques qui permettent de générer des instructions SSE en sont un autre exemple.
 
-La liste complète des fonctions intrinsèques exposées par le compilateur MSVC figurent dans le 
+La liste complète des fonctions intrinsèques proposées par le compilateur MSVC figurent dans le
 \href{http://go.yurichev.com/17254}{MSDN}.
 

--- a/other/itanium/main_FR.tex
+++ b/other/itanium/main_FR.tex
@@ -4,90 +4,90 @@
 
 Bien qu'elle n'ai pas réussi à percer, l'architecture  Intel Itanium (\ac{IA64}) est très intéressante.
 
-Là ou les CPUs \ac{OOE} réarrangent les instructions afin de les exécuter en parallèle, l'architecture 
+Là où les CPUs \ac{OOE} réarrangent les instructions afin de les exécuter en parallèle, l'architecture
 \ac{EPIC} a constitué une tentative pour déléguer cette décision au compilateur.
 
 Les compilateurs en question étaient évidemment particulièrement complexes.
 
-Voici un exemple de code pour l'architecture \ac{IA64} qui implémente un algorithme de 
+Voici un exemple de code pour l'architecture \ac{IA64} qui implémente un algorithme de
 chiffrage simple du noyau Linux:
 
 \lstinputlisting[caption=Linux kernel 3.2.0.4,style=customc]{other/itanium/tea_from_linux.c}
 
 Et voici maintenant le résultat de la compilation:
 
-\lstinputlisting[caption=Linux Kernel 3.2.0.4 for Itanium 2 (McKinley)]{other/itanium/ia64_linux_3.2.0.4_mckinley.lst}
+\lstinputlisting[caption=Linux Kernel 3.2.0.4 pour Itanium 2 (McKinley)]{other/itanium/ia64_linux_3.2.0.4_mckinley.lst}
 
 Nous constatons tout d'abord que toutes les instructions \ac{IA64} sont regroupées par 3.
 
-Chaque groupe représente 16 octets (128 bits) et se décompose en une catégorie de code sur 5 bits 
+Chaque groupe représente 16 octets (128 bits) et se décompose en une catégorie de code sur 5 bits
 puis 3 instructions de 41 bits chacune.
 
-Dans \IDA les groupes apparaissent sous la forme 6+6+4 octets~---le motif est facilement 
+Dans \IDA les groupes apparaissent sous la forme 6+6+4 octets~---le motif est facilement
 reconnaissable.
 
-En règle générale les trois instructions d'un groupe s'exécutent en parallèle, sauf si l'une d'elles 
+En règle générale les trois instructions d'un groupe s'exécutent en parallèle, sauf si l'une d'elles
 est associée à un \q{stop bit}.
 
-Il est probable que les ingénieurs d'Intel et de HP ont collecté des statistiques qui leur ont permis 
-d'identifier les motifs les plus fréquents. Ils auraient alors décidé d'introduire une notion de 
-type de groupe (\ac{AKA} \q{templates}). Le type du groupe définit la catégorie des instructions 
+Il est probable que les ingénieurs d'Intel et de HP ont collecté des statistiques qui leur ont permis
+d'identifier les motifs les plus fréquents. Ils auraient alors décidé d'introduire une notion de
+type de groupe (\ac{AKA} \q{templates}). Le type du groupe définit la catégorie des instructions
 qu'il contient. Ces catégories sont au nombre de 12.
 
-Par exemple, un groupe de type 0 représente \TT{MII}. Ceci signifie que la première instruction est 
-une lecture ou écriture en mémoire (M), la seconde et la troisième sont des manipulations d'entiers 
+Par exemple, un groupe de type 0 représente \TT{MII}. Ceci signifie que la première instruction est
+une lecture ou écriture en mémoire (M), la seconde et la troisième sont des manipulations d'entiers
 (I).
 
-Un autre exemple est le groupe de type 0x1d: \TT{MFB}. La première instruction est la aussi de type 
-mémoire (M), la seconde manipule un nombre flottant (F instruction \ac{FPU}), et le dernier est un 
+Un autre exemple est le groupe de type 0x1d: \TT{MFB}. La première instruction est la aussi de type
+mémoire (M), la seconde manipule un nombre flottant (F instruction \ac{FPU}), et la dernière est un
 branchement (B).
 
-Lorsque le compilateur ne parvient pas à sélectionner un instruction à inclure dans le groupe en 
-cours de construction, il utilise une instruction de type \ac{NOP}. Il existe donc des instructions 
-\TT{nop.i} pour remplacer ce qui devrait être une manipulation d'entier. De même un \TT{nop.m} est 
+Lorsque le compilateur ne parvient pas à sélectionner une instruction à inclure dans le groupe en
+cours de construction, il utilise une instruction de type \ac{NOP}. Il existe donc des instructions
+\TT{nop.i} pour remplacer ce qui devrait être une manipulation d'entier. De même un \TT{nop.m} est
 utilisé pour combler un trou là où une instruction de type mémoire devrait se trouver.
 
-Lorsque le programme est directement dédigé en assembleur, les instructions \ac{NOP}s sont ajoutées 
+Lorsque le programme est directement rédigé en assembleur, les instructions \ac{NOP}s sont ajoutées
 de manière automatique.
 
 Et ce n'est pas tout. Les groupes font eux-mêmes l'objet de regroupements.
 
-Chaque instruction peut être marquée avec un \q{stop bit}. Le processeur exécute en parallèle, toutes 
-les instructions jusqu'à ce qu'il rencontre un \q{stop bit}.
+Chaque instruction peut être marquée avec un \q{stop bit}. Le processeur exécute en parallèle toutes
+les instructions, jusqu'à ce qu'il rencontre un \q{stop bit}.
 
-En pratique, les processeurs Itanium 2 peuvent exécuter jusqu'à deux groupes simultanément, soit un 
+En pratique, les processeurs Itanium 2 peuvent exécuter jusqu'à deux groupes simultanément, soit un
 total de  6 instructions en parallèle.
 
-Il faut évidemment que les instructions exécutées en parallèle, n'aient  pas d'effet de bord entre 
-elles. Dans le cas contraire, le résultat n'est pas défini. 
-Le compilateur doit respecter cette contrainte ainsi que le nombre maximum de groupes simultanés du 
-processeur cible en placant les \q{stop bit} au bon endroit.
+Il faut évidemment que les instructions exécutées en parallèle, n'aient pas d'effet de bord entre
+elles. Dans le cas contraire, le résultat n'est pas défini.
+Le compilateur doit respecter cette contrainte ainsi que le nombre maximum de groupes simultanés du
+processeur cible en plaçant les \q{stop bit} au bon endroit.
 
-En langage assembleur, les bits d'arrêt sont identifiés par deux point-virgule situé après 
+En langage d'assemblage, les bits d'arrêt sont identifiés par deux point-virgule situés après
 l'instruction.
 
-Ainsi dans notre exemple les instructions [90-ac] peuvent être exécutées simultanément. Le prochain 
+Ainsi dans notre exemple les instructions [90-ac] peuvent être exécutées simultanément. Le prochain
 groupe est [b0-cc].
 
-Nous observons également un bit d'arrêt en 10c. L'instruction suivante comporte elle aussi un bit 
+Nous observons également un bit d'arrêt en 10c. L'instruction suivante comporte elle aussi un bit
 d'arrêt.
 
-Ces deux instructions doivent donc être exécutées isolément des autres, (comme dans une architecture 
+Ces deux instructions doivent donc être exécutées isolément des autres, (comme dans une architecture
 \ac{CISC}).
 
-En effet, l'instruction en 110 utilise le résultat produit par l'instruction précédente (valeur du 
+En effet, l'instruction en 110 utilise le résultat produit par l'instruction précédente (valeur du
 registre r26). Les deux instructions ne peuvent s'exécuter simultanément.
 
 Il semble que le compilateur n'ai pas trouvé de meilleure manière de paralléliser les instructions,
-ou en d'autres termes de plus charger la \ac{CPU}. Les bits d'arrêt sont donc en trop grand nombre.
+ou en d'autres termes, de plus charger la \ac{CPU}. Les bits d'arrêt sont donc en trop grand nombre.
 
-La rédaction manuelle de code en assembleur est une tâche pénible. Le programmeur doit effectuer 
+La rédaction manuelle de code en assembleur est une tâche pénible. Le programmeur doit effectuer
 lui-même les regroupements d'instructions.
 
-Bien sûr, il peut ajouter un bit d'arrêt à chaque instruction mais cela dégrade les performances 
+Bien sûr, il peut ajouter un bit d'arrêt à chaque instruction mais cela dégrade les performances
 telles qu'elles ont été pensée pour l'Itanium.
 
-Les codes source du noyau Linux contiennent un exemple intéressant d'un code assembleur produit 
+Les codes source du noyau Linux contiennent un exemple intéressant d'un code assembleur produit
 manuellement pour \ac{IA64}:
 
 \url{http://go.yurichev.com/17322}.
@@ -96,7 +96,7 @@ On trouvera une introduction à l'assembleur Itanium dans :
 [Mike Burrell, \IT{Writing Efficient Itanium 2 Assembly Code} (2010)]\footnote{\AlsoAvailableAs \url{http://yurichev.com/mirrors/RE/itanium.pdf}},
 [papasutra of haquebright, \IT{WRITING SHELLCODE FOR IA-64} (2001)]\footnote{\AlsoAvailableAs \url{http://phrack.org/issues/57/5.html}}.
 
-Deux autres caractéristiques très intéressantes d'Itanium feature sont la \IT{speculative execution} 
+Deux autres caractéristiques très intéressantes d'Itanium sont l'\IT{exécution spéculative}
 et le bit NaT (\q{not a thing}) qui ressemble un peu aux nombres \gls{NaN} : \\
 \href{http://go.yurichev.com/17323}{MSDN}.
 

--- a/patterns/03_printf/ARM/ARM3_FR.tex
+++ b/patterns/03_printf/ARM/ARM3_FR.tex
@@ -75,7 +75,7 @@ Le résultat est quelque peu inhabituel:
 
 \myindex{ARM!\Registers!Link Register}
 \myindex{ARM!\Instructions!B}
-\myindex{Épilogue de la fonction}
+\myindex{Epilogue de fonction}
 C'est la version optimisée (\Othree) pour le mode ARM et cette fois nous voyons
 \INS{B} comme dernière instruction au lieu du \INS{BL} habituel.
 Une autre différence entre cette version optimisée et la précédente (compilée

--- a/patterns/03_printf/ARM/ARM8_FR.tex
+++ b/patterns/03_printf/ARM/ARM8_FR.tex
@@ -34,7 +34,7 @@ Utilisons de nouveau l'exemple avec 9 arguments de la section précédente: \myr
 
 Ce code peut être divisé en plusieurs parties:
 
-\myindex{Prologue de la fonction}
+\myindex{Prologue de fonction}
 \begin{itemize}
 \item Prologue de la fonction:
 
@@ -84,7 +84,7 @@ les 5 autres valeurs sont passées par la pile:
 
 \item appel de \printf
 
-\myindex{Épilogue de fonction}
+\myindex{Epilogue de fonction}
 \item Épilogue de fonction:
 
 L'instruction \INS{ADD SP, SP, \#0x14} restaure le pointeur \ac{SP} à sa valeur


### PR DESCRIPTION
New part advanced - memmove
Several minor corrections.
Removed accentuated characters in index, for consistency.