### PR TITLE
French: translation

### DIFF
--- a/appendix/x86/instructions/INT_FR.tex
+++ b/appendix/x86/instructions/INT_FR.tex
@@ -27,7 +27,7 @@ en environnement 16-bit.
 
 \item[INT 3] (M): cette instruction est proche de
 \INS{INT}, elle a son propre opcode d'1 octet (\GTT{0xCC}),
-et est très utilisée pour le déboggage.
+et est très utilisée pour le débogage.
 Souvent, les débogueurs écrivent simplement l'octet \GTT{0xCC} à l'adresse du point
 d'arrêt à mettre, et lorsqu'une exception est levée, l'octet original est restauré
 et l'instruction originale à cette adresse est ré-exécutée. \\

--- a/examples/SAP/main.tex
+++ b/examples/SAP/main.tex
@@ -2,6 +2,8 @@
 
 \RU{\input{examples/SAP/sapgui/sapgui_RU}}
 \EN{\input{examples/SAP/sapgui/sapgui_EN}}
+\FR{\input{examples/SAP/sapgui/sapgui_FR}}
 \EN{\input{examples/SAP/pw/main_EN}}
 \RU{\input{examples/SAP/pw/main_RU}}
+\FR{\input{examples/SAP/pw/main_FR}}
 

--- a/examples/SAP/pw/main_FR.tex
+++ b/examples/SAP/pw/main_FR.tex
@@ -1,0 +1,140 @@
+\subsection{Fonctions de vérification de mot de passe de SAP 6.0}
+
+\myindex{SAP}
+
+Lorsque je suis retourné sur SAP 6.0 IDES installé sur une machine VMware, je me
+suis aperçu que j'avais oublié le mot de passe pour le compte SAP*, puis je m'en 
+suis souvenu, mais j'ai alors eu ce message
+\emph{<<Password logon no longer possible - too many failed attempts>>},
+car j'ai fait trop de tentatives avant de m'en rappeler.
+
+\myindex{Windows!PDB}
+
+La première très bonne nouvelle fût que le fichier \gls{PDB} complet de \emph{disp+work.pdb}
+était fourni avec SAP, et il contient presque tout: noms de fonction, structures,
+types, variable locale et nom d'arguments, etc. Quel cadeau somptueux!
+
+Il y a l'utilitaire TYPEINFODUMP\footnote{\url{http://go.yurichev.com/17038}} pour
+convertir les fichiers \gls{PDB} en quelque chose de lisible et grepable.
+
+Voici un exemple d'information d'une fonction + ses arguments + ses variables locales:
+
+\lstinputlisting{examples/SAP/pw/1.txt}
+
+Et voici un exemple d'une structure:
+
+\lstinputlisting{examples/SAP/pw/2.txt}
+
+Wow!
+
+Une autre bonne nouvelle: les appels de \emph{debugging} (il y en a beaucoup) sont
+très utiles.
+
+Ici, vous pouvez remarquer la variable globale \emph{ct\_level}\footnote{Plus d'information
+sur le niveau de trace: \url{http://go.yurichev.com/17039}}, qui reflète le niveau
+actuel de trace.
+
+Il y a beaucoup d'ajout de débogage dans le fichier \emph{disp+work.exe}:
+
+\lstinputlisting[style=customasmx86]{examples/SAP/pw/3.asm}
+
+Si le niveau courant de trace est plus élevé ou égal à la limite défini dans le code
+ici, un message de débogage est écrit dans les fichiers de log comme \emph{dev\_w0},
+\emph{dev\_disp}, et autres fichiers \emph{dev*}.
+
+\myindex{\GrepUsage}
+
+Essayons de grepper dans le fichier que nous avons obtenu à l'aide de l'utilitaire
+TYPEINFODUMP:
+
+\begin{lstlisting}
+cat "disp+work.pdb.d" | grep FUNCTION | grep -i password
+\end{lstlisting}
+
+Nous obtenons:
+
+\lstinputlisting{examples/SAP/pw/4.txt}
+
+Essayons aussi de chercher des messages de debug qui contiennent les mots \emph{<<password>>}
+et \emph{<<locked>>}.
+L'un d'entre eux se trouve dans la chaîne \emph{<<user was locked by subsequently
+failed password logon attempts>>}, référencé dans\\
+la fonction \emph{password\_attempt\_limit\_exceeded()}.
+
+D'autres chaînes que cette fonction peut écrire dans le fichier de log sont:
+\emph{<<password logon attempt will be rejected immediately (preventing dictionary attacks)>>},
+\emph{<<failed-logon lock: expired (but not removed due to 'read-only' operation)>>},
+\emph{<<failed-logon lock: expired => removed>>}.
+
+Après avoir joué un moment avec cette fonction, nous remarquons que le problème se
+situe exactement dedans.
+Elle est appelée depuis la fonction \emph{chckpass()}~---une des fonctions de vérification
+u mot de passe.
+
+d'abord, nous voulons être sûrs que nous sommes au bon endroit:
+
+Lançons \tracer:
+\myindex{tracer}
+
+\begin{lstlisting}
+tracer64.exe -a:disp+work.exe bpf=disp+work.exe!chckpass,args:3,unicode
+\end{lstlisting}
+
+\begin{lstlisting}
+PID=2236|TID=2248|(0) disp+work.exe!chckpass (0x202c770, L"Brewered1                               ", 0x41) (called from 0x1402f1060 (disp+work.exe!usrexist+0x3c0))
+PID=2236|TID=2248|(0) disp+work.exe!chckpass -> 0x35
+\end{lstlisting}
+
+L'enchaînement des appels est: \emph{syssigni()} -> \emph{DyISigni()} -> \emph{dychkusr()} -> \emph{usrexist()} -> \emph{chckpass()}.
+
+Le nombre 0x35 est une erreur renvoyée dans \emph{chckpass()} à cet endroit:
+
+\lstinputlisting[style=customasmx86]{examples/SAP/pw/5.asm}
+
+Bien, vérifions:
+
+\begin{lstlisting}
+tracer64.exe -a:disp+work.exe bpf=disp+work.exe!password_attempt_limit_exceeded,args:4,unicode,rt:0
+\end{lstlisting}
+
+\begin{lstlisting}
+PID=2744|TID=360|(0) disp+work.exe!password_attempt_limit_exceeded (0x202c770, 0, 0x257758, 0) (called from 0x1402ed58b (disp+work.exe!chckpass+0xeb))
+PID=2744|TID=360|(0) disp+work.exe!password_attempt_limit_exceeded -> 1
+PID=2744|TID=360|We modify return value (EAX/RAX) of this function to 0
+PID=2744|TID=360|(0) disp+work.exe!password_attempt_limit_exceeded (0x202c770, 0, 0, 0) (called from 0x1402e9794 (disp+work.exe!chngpass+0xe4))
+PID=2744|TID=360|(0) disp+work.exe!password_attempt_limit_exceeded -> 1
+PID=2744|TID=360|We modify return value (EAX/RAX) of this function to 0
+\end{lstlisting}
+
+Excellent! Nous pouvons nous connecter avec succès maintenant.
+
+À propos, nous pouvons prétendre que nous avons oublier le mot de passe, modifier
+la fonction \emph{chckpass()} afin qu'elle renvoie toujours une valeur de 0, ce qui
+est suffisant pour passer outre la vérification:
+
+\begin{lstlisting}
+tracer64.exe -a:disp+work.exe bpf=disp+work.exe!chckpass,args:3,unicode,rt:0
+\end{lstlisting}
+
+\begin{lstlisting}
+PID=2744|TID=360|(0) disp+work.exe!chckpass (0x202c770, L"bogus                                   ", 0x41) (called from 0x1402f1060 (disp+work.exe!usrexist+0x3c0))
+PID=2744|TID=360|(0) disp+work.exe!chckpass -> 0x35
+PID=2744|TID=360|We modify return value (EAX/RAX) of this function to 0
+\end{lstlisting}
+
+Ce que l'on peut aussi dire en analysant la fonction\\
+\emph{password\_attempt\_limit\_exceeded()},
+c'est qu'à son tout début, on voit cet appel:
+
+\lstinputlisting[style=customasmx86]{examples/SAP/pw/6.asm}
+
+Étonnement, la fonction \emph{sapgparam()} est utilisée pour chercher la valeur de
+certains paramètres de configuration. Cette fonction peut être appelée depuis 1768
+endroits différents.
+Il semble qu'avec l'aide de cette information, nous pouvons facilement trouver les
+endroits dans le code, où le contrôle du flux est affecté par des configurations
+spécifiques de paramètres.
+
+C'est vraiment agréable. Le nom des fonctions est très clair, bien plus que dans \oracle.
+\myindex{\Cpp}
+Il semble que le processus \emph{disp+work} est écrit en \Cpp. A-t-il été récrit il y a quelques temps?

--- a/examples/SAP/sapgui/1_FR.lst
+++ b/examples/SAP/sapgui/1_FR.lst
@@ -1,0 +1,30 @@
+
+.text:6440503C                 cmp     [ebp+var_10], ebx
+.text:6440503F                 jnz     exit ; passe outre l'affichage
+
+; ajoute les chaînes "For maximum data security delete" / "the setting(s) as soon as possible !":
+
+.text:64405045                 push    offset aForMaximumData ; \verb|"\nFor maximum data security delete\nthe s"...|
+.text:6440504A                 call    ds:mfc90_945 ; ATL::CStringT::operator+=(char const *)
+.text:64405050                 xor     edi, edi
+.text:64405052                 push    edi             ; fWinIni
+.text:64405053                 lea     eax, [ebp+pvParam]
+.text:64405056                 push    eax             ; pvParam
+.text:64405057                 push    edi             ; uiParam
+.text:64405058                 push    30h             ; uiAction
+.text:6440505A                 call    ds:SystemParametersInfoA
+.text:64405060                 mov     eax, [ebp+var_34]
+.text:64405063                 cmp     eax, 1600
+.text:64405068                 jle     short loc_64405072
+.text:6440506A                 cdq
+.text:6440506B                 sub     eax, edx
+.text:6440506D                 sar     eax, 1
+.text:6440506F                 mov     [ebp+var_34], eax
+.text:64405072
+.text:64405072 loc_64405072:
+
+start drawing:
+
+.text:64405072                 push    edi             ; hWnd
+.text:64405073                 mov     [ebp+cy], 0A0h
+.text:6440507A                 call    ds:GetDC

--- a/examples/SAP/sapgui/2_FR.lst
+++ b/examples/SAP/sapgui/2_FR.lst
@@ -1,0 +1,3 @@
+
+.text:6440503F                 jnz     exit ; passe outre l'affichage
+

--- a/examples/SAP/sapgui/3_FR.lst
+++ b/examples/SAP/sapgui/3_FR.lst
@@ -1,0 +1,28 @@
+.text:64404C19 sub_64404C19    proc near
+.text:64404C19
+.text:64404C19 arg_0           = dword ptr  4
+.text:64404C19
+.text:64404C19                 push    ebx
+.text:64404C1A                 push    ebp
+.text:64404C1B                 push    esi
+.text:64404C1C                 push    edi
+.text:64404C1D                 mov     edi, [esp+10h+arg_0]
+.text:64404C21                 mov     eax, [edi]
+.text:64404C23                 mov     esi, ecx ; ESI/ECX sont des pointeurs sur un objet inconnu
+.text:64404C25                 mov     [esi], eax
+.text:64404C27                 mov     eax, [edi+4]
+.text:64404C2A                 mov     [esi+4], eax
+.text:64404C2D                 mov     eax, [edi+8]
+.text:64404C30                 mov     [esi+8], eax
+.text:64404C33                 lea     eax, [edi+0Ch]
+.text:64404C36                 push    eax
+.text:64404C37                 lea     ecx, [esi+0Ch]
+
+; \verb|demangled name:  ATL::CStringT::operator=(class ATL::CStringT ... &)|
+.text:64404C3A                 call    ds:mfc90_817 
+.text:64404C40                 mov     eax, [edi+10h]
+.text:64404C43                 mov     [esi+10h], eax
+.text:64404C46                 mov     al, [edi+14h]
+.text:64404C49                 mov     [esi+14h], al
+.text:64404C4C                 mov     al, [edi+15h] ; cope l'octet de l'offset 0x15
+.text:64404C4F                 mov     [esi+15h], al ; dans l'offset 0x15 de l'objet CDwsGui

--- a/examples/SAP/sapgui/4_FR.lst
+++ b/examples/SAP/sapgui/4_FR.lst
@@ -1,0 +1,7 @@
+.text:6440B0BF loc_6440B0BF:
+.text:6440B0BF                 mov     eax, [ebp+arg_0]
+.text:6440B0C2                 push    [ebp+arg_4]
+.text:6440B0C5                 mov     [esi+2844h], eax
+.text:6440B0CB                 lea     eax, [esi+28h] ; ESI est un pointeur sur l'objet CDwsGui
+.text:6440B0CE                 push    eax
+.text:6440B0CF                 call    CDwsGui__CopyOptions

--- a/examples/SAP/sapgui/5_FR.lst
+++ b/examples/SAP/sapgui/5_FR.lst
@@ -1,0 +1,19 @@
+.text:64409D58                 cmp     [esi+3Dh], bl   ; ESI est un pointeur sur l'objet CDwsGui
+.text:64409D5B                 lea     ecx, [esi+2B8h]
+.text:64409D61                 setz    al
+.text:64409D64                 push    eax ; arg\_10 de CConnectionContext::CreateNetwork
+.text:64409D65                 push    dword ptr [esi+64h]
+
+; nom original: const char* ATL::CSimpleStringT::operator PCXSTR 
+.text:64409D68                 call    ds:mfc90_910
+.text:64409D68                                         ; pas d'arguments
+.text:64409D6E                 push    eax
+.text:64409D6F                 lea     ecx, [esi+2BCh]
+
+; nom orignal: const char* ATL::CSimpleStringT::operator PCXSTR 
+.text:64409D75                 call    ds:mfc90_910
+.text:64409D75                                         ; pas d'arguments
+.text:64409D7B                 push    eax
+.text:64409D7C                 push    esi
+.text:64409D7D                 lea     ecx, [esi+8]
+.text:64409D80                 call    CConnectionContext__CreateNetwork

--- a/examples/SAP/sapgui/6_FR.lst
+++ b/examples/SAP/sapgui/6_FR.lst
@@ -1,0 +1,19 @@
+.text:64411DF1                 cmp     [ebp+compression], esi
+.text:64411DF7                 jz      short set_EAX_to_0
+.text:64411DF9                 mov     al, [ebx+78h]   ; une autre valeur pourrait affecter la compression?
+.text:64411DFC                 cmp     al, '3'
+.text:64411DFE                 jz      short set_EAX_to_1
+.text:64411E00                 cmp     al, '4'
+.text:64411E02                 jnz     short set_EAX_to_0
+.text:64411E04
+.text:64411E04 set_EAX_to_1:
+.text:64411E04                 xor     eax, eax
+.text:64411E06                 inc     eax             ; EAX -> 1
+.text:64411E07                 jmp     short loc_64411E0B
+.text:64411E09
+.text:64411E09 set_EAX_to_0:
+.text:64411E09
+.text:64411E09                 xor     eax, eax        ; EAX -> 0
+.text:64411E0B
+.text:64411E0B loc_64411E0B:
+.text:64411E0B                 mov     [ebx+3A4h], eax ; EBX est un pointeur sur l'object CNetwork

--- a/examples/SAP/sapgui/7_FR.lst
+++ b/examples/SAP/sapgui/7_FR.lst
@@ -1,0 +1,35 @@
+.text:64406F76 loc_64406F76:
+.text:64406F76                 mov     ecx, [ebp+7728h+var_7794]
+.text:64406F79                 cmp     dword ptr [ecx+3A4h], 1
+.text:64406F80                 jnz     compression_flag_is_zero
+.text:64406F86                 mov     byte ptr [ebx+7], 1
+.text:64406F8A                 mov     eax, [esi+18h]
+.text:64406F8D                 mov     ecx, eax
+.text:64406F8F                 test    eax, eax
+.text:64406F91                 ja      short loc_64406FFF
+.text:64406F93                 mov     ecx, [esi+14h]
+.text:64406F96                 mov     eax, [esi+20h]
+.text:64406F99
+.text:64406F99 loc_64406F99:
+.text:64406F99                 push    dword ptr [edi+2868h] ; int
+.text:64406F9F                 lea     edx, [ebp+7728h+var_77A4]
+.text:64406FA2                 push    edx             ; int
+.text:64406FA3                 push    30000           ; int
+.text:64406FA8                 lea     edx, [ebp+7728h+Dst]
+.text:64406FAB                 push    edx             ; Dst
+.text:64406FAC                 push    ecx             ; int
+.text:64406FAD                 push    eax             ; Src
+.text:64406FAE                 push    dword ptr [edi+28C0h] ; int
+.text:64406FB4                 call    sub_644055C5       ; routine de compression actuelle
+.text:64406FB9                 add     esp, 1Ch
+.text:64406FBC                 cmp     eax, 0FFFFFFF6h
+.text:64406FBF                 jz      short loc_64407004
+.text:64406FC1                 cmp     eax, 1
+.text:64406FC4                 jz      loc_6440708C
+.text:64406FCA                 cmp     eax, 2
+.text:64406FCD                 jz      short loc_64407004
+.text:64406FCF                 push    eax
+.text:64406FD0                 push    offset aCompressionErr ; \verb|"compression error [rc = %d]- program wi"...|
+.text:64406FD5                 push    offset aGui_err_compre ; \verb|"GUI_ERR_COMPRESS"|
+.text:64406FDA                 push    dword ptr [edi+28D0h]
+.text:64406FE0                 call    SapPcTxtRead

--- a/examples/SAP/sapgui/8.lst
+++ b/examples/SAP/sapgui/8.lst
@@ -1,0 +1,3 @@
+.text:6441747C                 push    offset aErrorCsrcompre ; \verb|"\nERROR: CsRCompress: invalid handle"|
+.text:64417481                 call    eax ; \verb|dword_644F94C8|
+.text:64417483                 add     esp, 4

--- a/examples/SAP/sapgui/sapgui_FR.tex
+++ b/examples/SAP/sapgui/sapgui_FR.tex
@@ -1,0 +1,237 @@
+\subsection{À propos de la compression du trafic réseau par le client SAP}
+\label{sec:SAPGUI}
+
+\newcommand{\TDWNC}{TDW\_NOCOMPRESS\xspace}
+
+(Tracer la connexion entre la variable d'environnement \TDWNC{} SAPGUI\footnote{client SAP GUI}
+et la fenêtre pop-up gênante et ennuyeuse et la routine de compression de données actuelle.)
+ 
+On sait que le trafic réseau entre le SAPGUI et SAP n'est pas chiffré par défaut,
+mais compressé (voir ici\footnote{\url{http://go.yurichev.com/17221}} et
+ici\footnote{\href{http://go.yurichev.com/17225}{blog.yurichev.com}}).
+
+Il est aussi connue que mettre la variable d'environnement \emph{\TDWNC} à 1,
+permet d'arrêter la compression des paquets réseau.
+
+Mais vous verrez toujours l'ennuyeuse fenêtre pop-up, qui ne peut pas être fermée:
+
+\begin{figure}[H]
+\centering
+\myincludegraphics{examples/SAP/sapgui/sapgui720.png}
+\caption{Screenshot}
+\end{figure}
+
+Voyons si nous pouvons supprimer cette fenêtre.
+
+Mais avant, voyons ce que nous savons déjà:
+
+Premièrement: nous savons que la variable d'environnement \emph{\TDWNC} est vérifiée
+quelque part dans le client SAPGUI.
+
+Deuxièmement: une chaîne comme \q{data compression switched off} doit s'y trouver
+quelque part.
+\newcommand{\FNURLFAR}{\footnote{\url{http://go.yurichev.com/17347}}}
+
+Avec l'aide du gestionnaire de fichier FAR\FNURLFAR nous pouvons trouver que deux
+de ces chaînes sont stockées dans le fichier SAPguilib.dll.
+
+Donc ouvrons SAPguilib.dll dans \IDA et cherchons la chaîne \emph{\TDWNC}.
+Oui, elle s'y trouve et il n'y a qu'une référence vers elle.
+
+Nous voyons le morceau de code suivant (tous les offsets de fichiers sont valables
+pour SAPGUI 720 win32, fichier SAPguilib.dll version 7200,1,0,9009):
+
+\lstinputlisting[style=customasmx86]{examples/SAP/sapgui/0.lst}
+
+\myindex{\CStandardLibrary!atoi()}
+
+La chaîne renvoyée par \TT{chk\_env()} via son second argument est ensuite traitée
+par la fonction de chaîne MFC et ensuite \TT{atoi()}\footnote{fonction C standard
+qui convertit les chiffres d'une chaîne en un nombre} est appelée.
+Après ça, la valeur numérique est stockée en \TT{edi+15h}.
+
+Jetons aussi un \oe{}il à la fonction \TT{chk\_env()} (nous avons donné ce nom manuellement):
+
+\lstinputlisting[style=customasmx86]{examples/SAP/sapgui/01.lst}
+
+\myindex{\CStandardLibrary!getenv()}
+Oui. La fonction \TT{getenv\_s()}\footnote{\href{http://go.yurichev.com/17250}{MSDN}}
+
+est une version de Microsoft à la sécurité avancée de \TT{getenv()}\footnote{Fonction
+de la bibliothèque C standard renvoyant une variable d'environnement}.
+
+\myindex{MFC}
+
+Il y a quelques manipulation de chaîne MFC.
+
+De nombreuses autres variables d'environnement sont également testées.
+Voici une liste de toutes les variables qui sont testé et ce que SAPGUI écrirait
+dans son fichier de log, lorsque les traces sont activées:
+
+\input{examples/SAP/sapgui/options}
+
+La configuration de chaque variable est écrit dans le tableau via le pointeur dans
+le registre \EDI. \EDI est renseigné avant l'appel à la fonction:
+
+\begin{lstlisting}[style=customasmx86]
+.text:6440EE00                 lea     edi, [ebp+2884h+var_2884] ; options here like +0x15...
+.text:6440EE03                 lea     ecx, [esi+24h]
+.text:6440EE06                 call    load_command_line
+.text:6440EE0B                 mov     edi, eax
+.text:6440EE0D                 xor     ebx, ebx
+.text:6440EE0F                 cmp     edi, ebx
+.text:6440EE11                 jz      short loc_6440EE42
+.text:6440EE13                 push    edi
+.text:6440EE14                 push    offset aSapguiStoppedA ; "Sapgui stopped after commandline interp"...
+.text:6440EE19                 push    dword_644F93E8
+.text:6440EE1F                 call    FEWTraceError
+\end{lstlisting}
+
+Maintenant, pouvons-nous trouver la chaîne \emph{data record mode switched on}?
+
+Oui, et la seule référence est dans
+\par \TT{CDwsGui::PrepareInfoWindow()}.
+
+Comment connaissons-nous les noms de classe/méthode? Il y a beaucoup d'appels spéciaux
+de débogage qui écrivent dans les fichiers de log, comme:
+
+\lstinputlisting[style=customasmx86]{examples/SAP/sapgui/02.lst}
+
+\dots ou:
+
+\begin{lstlisting}[style=customasmx86]
+.text:6440237A                 push    eax
+.text:6440237B                 push    offset aCclientStart_6 ; "CClient::Start: set shortcut user to '\%"...
+.text:64402380                 push    dword ptr [edi+4]
+.text:64402383                 call    dbg
+.text:64402388                 add     esp, 0Ch
+\end{lstlisting}
+
+C'est \emph{très} utile.
+
+Voyons le contenu de la fonction de cette fenêtre pop-up ennuyeuse:
+
+\lstinputlisting[style=customasmx86]{examples/SAP/sapgui/03.lst}
+
+Au début de la fonction, \ECX a un pointeur sur l'objet (puisque c'est une fonction
+avec le type d'appel thiscall~(\myref{thiscall})).
+Dans notre cas, l'objet a étonnement un type de classe de \emph{CDwsGui}.
+En fonction de l'option mise dans l'objet, un message spécifique est concaténé au
+message résultant.
+
+Si la valeur à l'adresse \TT{this+0x3D} n'est pas zéro, la compression est désactivée:
+
+\lstinputlisting[style=customasmx86]{examples/SAP/sapgui/04.lst}
+
+Finalement, il est intéressant de noter que l'état de la variable \emph{var\_10}
+défini si le message est affiché:
+
+\lstinputlisting[style=customasmx86]{examples/SAP/sapgui/1_FR.lst}
+
+Vérifions notre théorie en pratique.
+
+\JNZ à cette ligne \dots
+
+\lstinputlisting[style=customasmx86]{examples/SAP/sapgui/2_FR.lst}
+
+\dots 
+remplaçons-le par un \JMP, et nous obtenons SAPGUI fonctionnant sans que l'ennuyeuse
+fenêtre pop-up n'apparaisse!
+
+Maintenant approfondissons et trouvons la relation entre l'offset $0x15$ dans la
+fonction \TT{load\_command\_line()} (nous lui avons donné ce nom) et la variable
+\TT{this+0x3D} dans \emph{CDwsGui::PrepareInfoWindow}.
+Sommes-nous sûrs que la valeur est la même?
+
+Nous commençons par chercher toutes les occurrences de la valeur \TT{0x15} dans le
+code.
+Pour un petit programme comme SAPGUI, cela fonctionne parfois.a Voici la première
+occurrence que nous obtenons:
+
+\lstinputlisting[style=customasmx86]{examples/SAP/sapgui/3_FR.lst}
+
+La fonction a été appelée depuis la fonction appelée \emph{CDwsGui::CopyOptions}!
+Encore merci pour les informations de débogage.
+
+Mais la vraie réponse est dans \emph{CDwsGui::Init()}:
+
+\lstinputlisting[style=customasmx86]{examples/SAP/sapgui/4_FR.lst}
+
+Enfin, nous comprennons: le tableau rempli dans la fonction \TT{load\_command\_line()}
+est stocké dans la classe \emph{CDwsGui} mais à l'adresse \TT{this+0x28}. 0x15 + 0x28
+vaut exactement 0x3D. OK, nous avons trouvé le point où la valeur y est copiée.
+
+Trouvons les autres endroits où l'offset 0x3D est utilisé.
+Voici l'un d'entre eux dans la fonction \emph{CDwsGui::SapguiRun} (à nouveau, merci
+aux appels de débogage):
+
+\lstinputlisting[style=customasmx86]{examples/SAP/sapgui/5_FR.lst}
+
+Vérifions nos découvertes. \\
+Remplaçons \TT{setz al} par les instructions \TT{xor eax, eax / nop},
+effaçons la variable d'environnement \TDWNC et lançons SAPGUI. Ouah! La fenêtre ennuyeuse
+n'est plus là (comme nous l'attendions, puisque la variable d'environnement n'est
+pas mise) mais dans Wireshark nous pouvons voir que les paquets réseau ne sont plus
+compressés!
+Visiblement, c'est le point où le flag de compression doit être défini dans l'objet
+\emph{CConnectionContext}.
+
+Donc, le flag de compression est passé dans le 5-ème argument de \emph{CConnectionContext::CreateNetwork}.
+À l'intérieur de la fonction, une autre est appelée:
+
+\begin{lstlisting}[style=customasmx86]
+...
+.text:64403476                 push    [ebp+compression]
+.text:64403479                 push    [ebp+arg_C]
+.text:6440347C                 push    [ebp+arg_8]
+.text:6440347F                 push    [ebp+arg_4]
+.text:64403482                 push    [ebp+arg_0]
+.text:64403485                 call    CNetwork__CNetwork
+\end{lstlisting}
+
+Le flag de compression est passé ici dans le 5-ème argument au constructer \emph{CNetwork::CNetwork}.
+
+Et voici comment le constructeur \emph{CNetwork} défini le flag dans l'objet \emph{CNetwork}
+suivant son 5-ème argument \emph{et} une autre variable qui peut probablement aussi
+affecter la compression des paquets réseau.
+
+\lstinputlisting[style=customasmx86]{examples/SAP/sapgui/6_FR.lst}
+
+À ce point, nous savons que le flag de compression est stocké dans la classe
+\emph{CNetwork} à l'adresse \emph{this+0x3A4}.
+
+Plongeons-nous maintenant dans SAPguilib.dll à la recherche de la valeur \TT{0x3A4}.
+Et il y a une seconde occurrence dans \emph{CDwsGui::OnClientMessageWrite} (Merci
+infiniment pour les informations de débogage):
+
+\lstinputlisting[style=customasmx86]{examples/SAP/sapgui/7_FR.lst}
+
+Jetons un \oe{}il dans \emph{sub\_644055C5}. Nous y voyons seulement l'appel à memcpy()
+et une autre fonction appelée (par \IDA) \emph{sub\_64417440}.
+
+Et, regardons dans \emph{sub\_64417440}. Nous y voyons:
+
+\lstinputlisting[style=customasmx86]{examples/SAP/sapgui/8.lst}
+
+Voilà! Nous avons trouvé la fonction qui effectue la compression des données.
+Comme cela a été décrit dans le passé
+\footnote{\url{http://go.yurichev.com/17312}},
+
+cette fonction est utilisé dans SAP et aussi dans le projet open-source MaxDB.
+Donc, elle est disponible sous forme de code source.
+
+La dernière vérification est faite ici:
+
+\begin{lstlisting}[style=customasmx86]
+.text:64406F79                 cmp     dword ptr [ecx+3A4h], 1
+.text:64406F80                 jnz     compression_flag_is_zero
+\end{lstlisting}
+
+Remplaçons ici \JNZ par un \JMP inconditionnel. Supprimons la variable d'environnement
+\TDWNC. Voilà!
+
+Dans Wireshark nous voyons que les messages du client ne sont pas compressés. Les
+réponses du serveur, toutefois, le sont.
+
+Donc nous avons trouvé le lien entre la variable d'environnement et le point où la
+routine de compression peut être appelée ou non.

--- a/examples/examples_FR.tex
+++ b/examples/examples_FR.tex
@@ -26,7 +26,7 @@
 %% TODO \input{examples/encrypted_DB1/main_FR}
 %% TODO \input{examples/bitcoin_miner/main_FR}
 %% TODO \input{examples/simple_exec_crypto/main_FR}
-%% TODO \input{examples/SAP/main_FR}
+\input{examples/SAP/main}
 %% TODO \input{examples/oracle/main_FR}
 \input{examples/handcoding/main_FR}
 \input{examples/demos/main}


### PR DESCRIPTION
It's the examples/SAP part.
I've added a 8.lst file, as the 8_EN.lst does not contain English to be translated.
I don't know if it should be 05.lst instead.
I let you have a look, but I guess it would be better to drop the 8_EN.lst file.