### PR TITLE
French translation, minor typos

### DIFF
--- a/examples/bitcoin_miner/main_FR.tex
+++ b/examples/bitcoin_miner/main_FR.tex
@@ -1,0 +1,305 @@
+\mysection{Overclocker le mineur de Bitcoin Cointerra}
+\index{Bitcoin}
+\index{BeagleBone}
+
+Il y avait le mineur de Bitcoin Cointerra, ressemblant à ceci:
+
+\begin{figure}[H]
+\centering
+\myincludegraphics{examples/bitcoin_miner/board.jpg}
+\caption{Carte}
+\end{figure}
+
+Et il y avait aussi (peut-être leaké) l'utilitaire\footnote{Peut être téléchargé ici: \url{https://github.com/DennisYurichev/RE-for-beginners/raw/master/examples/bitcoin_miner/files/cointool-overclock}}
+qui peut définir la fréquence d'horloge pour la carte.
+Il fonctionne sur une carte additionnelle BeagleBone Linux ARM (petite carte en bas
+de l'image).
+
+Et on m'avait demandé une fois s'il est possible de modifier cet utilitaire pour voir
+quelles sont les fréquences qui peuvent être définies, et celles qui ne peuvent pas
+l'être.
+Et est-il possible de l'ajuster?
+
+L'utilitaire doit être exécuté comme cela: \TT{./cointool-overclock 0 0 900}, où 900
+est la fréquence en MHz.
+Si la fréquence est trop grande, l'utilitaire affiche \q{Error with arguments} et
+se termine.
+
+Ceci est le morceau de code autour de la référence à la chaîne de texte \q{Error with arguments}:
+
+\begin{lstlisting}[style=customasmARM]
+
+...
+
+.text:0000ABC4         STR      R3, [R11,#var_28]
+.text:0000ABC8         MOV      R3, #optind
+.text:0000ABD0         LDR      R3, [R3]
+.text:0000ABD4         ADD      R3, R3, #1
+.text:0000ABD8         MOV      R3, R3,LSL#2
+.text:0000ABDC         LDR      R2, [R11,#argv]
+.text:0000ABE0         ADD      R3, R2, R3
+.text:0000ABE4         LDR      R3, [R3]
+.text:0000ABE8         MOV      R0, R3  ; nptr
+.text:0000ABEC         MOV      R1, #0  ; endptr
+.text:0000ABF0         MOV      R2, #0  ; base
+.text:0000ABF4         BL       strtoll
+.text:0000ABF8         MOV      R2, R0
+.text:0000ABFC         MOV      R3, R1
+.text:0000AC00         MOV      R3, R2
+.text:0000AC04         STR      R3, [R11,#var_2C]
+.text:0000AC08         MOV      R3, #optind
+.text:0000AC10         LDR      R3, [R3]
+.text:0000AC14         ADD      R3, R3, #2
+.text:0000AC18         MOV      R3, R3,LSL#2
+.text:0000AC1C         LDR      R2, [R11,#argv]
+.text:0000AC20         ADD      R3, R2, R3
+.text:0000AC24         LDR      R3, [R3]
+.text:0000AC28         MOV      R0, R3  ; nptr
+.text:0000AC2C         MOV      R1, #0  ; endptr
+.text:0000AC30         MOV      R2, #0  ; base
+.text:0000AC34         BL       strtoll
+.text:0000AC38         MOV      R2, R0
+.text:0000AC3C         MOV      R3, R1
+.text:0000AC40         MOV      R3, R2
+.text:0000AC44         STR      R3, [R11,#third_argument]
+.text:0000AC48         LDR      R3, [R11,#var_28]
+.text:0000AC4C         CMP      R3, #0
+.text:0000AC50         BLT      errors_with_arguments
+.text:0000AC54         LDR      R3, [R11,#var_28]
+.text:0000AC58         CMP      R3, #1
+.text:0000AC5C         BGT      errors_with_arguments
+.text:0000AC60         LDR      R3, [R11,#var_2C]
+.text:0000AC64         CMP      R3, #0
+.text:0000AC68         BLT      errors_with_arguments
+.text:0000AC6C         LDR      R3, [R11,#var_2C]
+.text:0000AC70         CMP      R3, #3
+.text:0000AC74         BGT      errors_with_arguments
+.text:0000AC78         LDR      R3, [R11,#third_argument]
+.text:0000AC7C         CMP      R3, #0x31
+.text:0000AC80         BLE      errors_with_arguments
+.text:0000AC84         LDR      R2, [R11,#third_argument]
+.text:0000AC88         MOV      R3, #950
+.text:0000AC8C         CMP      R2, R3
+.text:0000AC90         BGT      errors_with_arguments
+.text:0000AC94         LDR      R2, [R11,#third_argument]
+.text:0000AC98         MOV      R3, #0x51EB851F
+.text:0000ACA0         SMULL    R1, R3, R3, R2
+.text:0000ACA4         MOV      R1, R3,ASR#4
+.text:0000ACA8         MOV      R3, R2,ASR#31
+.text:0000ACAC         RSB      R3, R3, R1
+.text:0000ACB0         MOV      R1, #50
+.text:0000ACB4         MUL      R3, R1, R3
+.text:0000ACB8         RSB      R3, R3, R2
+.text:0000ACBC         CMP      R3, #0
+.text:0000ACC0         BEQ      loc_ACEC
+.text:0000ACC4
+.text:0000ACC4 errors_with_arguments
+.text:0000ACC4                                         
+.text:0000ACC4         LDR      R3, [R11,#argv]
+.text:0000ACC8         LDR      R3, [R3]
+.text:0000ACCC         MOV      R0, R3  ; path
+.text:0000ACD0         BL       __xpg_basename
+.text:0000ACD4         MOV      R3, R0
+.text:0000ACD8         MOV      R0, #aSErrorWithArgu ; format
+.text:0000ACE0         MOV      R1, R3
+.text:0000ACE4         BL       printf
+.text:0000ACE8         B        loc_ADD4
+.text:0000ACEC ; ------------------------------------------------------------
+.text:0000ACEC
+.text:0000ACEC loc_ACEC                 ; CODE XREF: main+66C
+.text:0000ACEC         LDR      R2, [R11,#third_argument]
+.text:0000ACF0         MOV      R3, #499
+.text:0000ACF4         CMP      R2, R3
+.text:0000ACF8         BGT      loc_AD08
+.text:0000ACFC         MOV      R3, #0x64
+.text:0000AD00         STR      R3, [R11,#unk_constant]
+.text:0000AD04         B        jump_to_write_power
+.text:0000AD08 ; ------------------------------------------------------------
+.text:0000AD08
+.text:0000AD08 loc_AD08                 ; CODE XREF: main+6A4
+.text:0000AD08         LDR      R2, [R11,#third_argument]
+.text:0000AD0C         MOV      R3, #799
+.text:0000AD10         CMP      R2, R3
+.text:0000AD14         BGT      loc_AD24
+.text:0000AD18         MOV      R3, #0x5F
+.text:0000AD1C         STR      R3, [R11,#unk_constant]
+.text:0000AD20         B        jump_to_write_power
+.text:0000AD24 ; ------------------------------------------------------------
+.text:0000AD24
+.text:0000AD24 loc_AD24                 ; CODE XREF: main+6C0
+.text:0000AD24         LDR      R2, [R11,#third_argument]
+.text:0000AD28         MOV      R3, #899
+.text:0000AD2C         CMP      R2, R3
+.text:0000AD30         BGT      loc_AD40
+.text:0000AD34         MOV      R3, #0x5A
+.text:0000AD38         STR      R3, [R11,#unk_constant]
+.text:0000AD3C         B        jump_to_write_power
+.text:0000AD40 ; ------------------------------------------------------------
+.text:0000AD40
+.text:0000AD40 loc_AD40                 ; CODE XREF: main+6DC
+.text:0000AD40         LDR      R2, [R11,#third_argument]
+.text:0000AD44         MOV      R3, #999
+.text:0000AD48         CMP      R2, R3
+.text:0000AD4C         BGT      loc_AD5C
+.text:0000AD50         MOV      R3, #0x55
+.text:0000AD54         STR      R3, [R11,#unk_constant]
+.text:0000AD58         B        jump_to_write_power
+.text:0000AD5C ; ------------------------------------------------------------
+.text:0000AD5C
+.text:0000AD5C loc_AD5C                 ; CODE XREF: main+6F8
+.text:0000AD5C         LDR      R2, [R11,#third_argument]
+.text:0000AD60         MOV      R3, #1099
+.text:0000AD64         CMP      R2, R3
+.text:0000AD68         BGT      jump_to_write_power
+.text:0000AD6C         MOV      R3, #0x50
+.text:0000AD70         STR      R3, [R11,#unk_constant]
+.text:0000AD74
+.text:0000AD74 jump_to_write_power                     ; CODE XREF: main+6B0
+.text:0000AD74                                         ; main+6CC ...
+.text:0000AD74         LDR      R3, [R11,#var_28]
+.text:0000AD78         UXTB     R1, R3
+.text:0000AD7C         LDR      R3, [R11,#var_2C]
+.text:0000AD80         UXTB     R2, R3
+.text:0000AD84         LDR      R3, [R11,#unk_constant]
+.text:0000AD88         UXTB     R3, R3
+.text:0000AD8C         LDR      R0, [R11,#third_argument]
+.text:0000AD90         UXTH     R0, R0
+.text:0000AD94         STR      R0, [SP,#0x44+var_44]
+.text:0000AD98         LDR      R0, [R11,#var_24]
+.text:0000AD9C         BL       write_power
+.text:0000ADA0         LDR      R0, [R11,#var_24]
+.text:0000ADA4         MOV      R1, #0x5A
+.text:0000ADA8         BL       read_loop
+.text:0000ADAC         B        loc_ADD4
+
+...
+
+.rodata:0000B378 aSErrorWithArgu DCB "%s: Error with arguments",0xA,0 ; DATA XREF: main+684
+
+...
+
+\end{lstlisting}
+
+Les noms de fonctions étaient présents dans les informations de débogage du binaire
+original, comme \TT{write\_power}, \TT{read\_loop}.
+Mais j'ai nommé les labels à l'intérieur des fonctions.
+
+\myindex{UNIX!getopt}
+\myindex{strtoll()}
+Le nom \TT{optind} semble familier. Il provient de la bibliothèque *NIX \emph{getopt}
+qui sert à traiter les arguments de la ligne de commande---bien, c'est exactement
+ce qui se passe dans ce code.
+Ensuite, le 3ème argument (où la valeur de la fréquence est passée) est converti
+d'une chaîne vers un nombre en utilisant un appel à la fonction \emph{strtoll()}.
+
+La valeur est ensuite encore comparée par rapport à diverses constantes.
+En 0xACEC, elle est testée, si elle est inférieure ou égale à 499, et si c'est le
+cas, 0x64 est passé à la fonction \TT{write\_power()} (qui envoie une commande par
+USB en utilisant \TT{send\_msg()}).
+Si elle est plus grande que 499, un saut en 0xAD08 se produit.
+
+En 0xAD08 on teste si elle est inférieure ou égale à 799. En cas de succès 0x5F est
+alors passé à la fonction \TT{write\_power()}.
+
+Il y a d'autres tests: par rapport à 899 en 0xAD24, à 0x999 en 0xAD40 et enfin,
+à 1099 en 0xAD5C.
+Si la fréquence est inférieure ou égale à 1099, 0x50 est passé (en 0xAD6C) à la fonction
+\TT{write\_power()}.
+Et il y a une sorte de bug.
+Si la valeur est encore plus grande que 1099, la valeur elle-même est passée à la
+fonction \TT{write\_power()}.
+Oh, ce n'est pas un bug, car nous ne pouvons pas arriver là: la valeur est d'abord
+comparée à 950 en 0xAC88, et si elle est plus grande, un message d'erreur est
+affiché et l'utilitaire s'arrête.
+
+Maintenant, la table des fréquences en MHz et la valeur passée à la fonction \TT{write\_power()}:
+
+\begin{center}
+\begin{longtable}{ | l | l | l | }
+\hline
+\HeaderColor MHz & \HeaderColor héxadecimal & \HeaderColor décimal \\
+\hline
+499MHz & 0x64 & 100 \\
+\hline
+799MHz & 0x5f & 95 \\
+\hline
+899MHz & 0x5a & 90 \\
+\hline
+999MHz & 0x55 & 85 \\
+\hline
+1099MHz & 0x50 & 80 \\
+\hline
+\end{longtable}
+\end{center}
+
+Il semble que la valeur passée à la carte décroît lorsque la fréquence croît.
+
+Maintenant, nous voyons que la valeur de 950MHz est codée en dur, au moins dans cet
+utilitaire. Pouvons-nous le truquer?
+
+Retournons à ce morceau de code:
+
+\begin{lstlisting}[style=customasmARM]
+.text:0000AC84      LDR     R2, [R11,#third_argument]
+.text:0000AC88      MOV     R3, #950
+.text:0000AC8C      CMP     R2, R3
+.text:0000AC90      BGT     errors_with_arguments ; j'ai modifié ici en 00 00 00 00
+\end{lstlisting}
+
+Nous devons désactiver l'instruction de branchement \INS{BGT} en 0xAC90. Et ceci est
+du ARM en mode ARM, car, comme on le voit, toutes les adresses augmentent par 4,
+i.e, chaque instruction a une taille de 4 octets.
+L'instruction \TT{NOP} (no operation) en mode ARM est juste quatre octets à zéro:
+\TT{00 00 00 00}.
+Donc en écrivant quatre octets à zéro à l'adresse 0xAC90 (ou à l'offset 0x2C90 dans
+le fichier), nous pouvons désactiver le test.
+
+Maintenant, il est possible de définir la fréquence jusqu'à 1050MHz. Et même plus,
+mais, à cause du bug, si la valeur en entrée est plus grande que 1099, la valeur
+\emph{telle quelle} en MHz sera passée à la carte, ce qui est incorrect.
+
+Je ne suis  pas allé plus loin, mais si je devais, j'essayerai de diminuer la valeur
+qui est passée à la fonction \TT{write\_power()}.
+
+Maintenant, le morceau de code effrayant que j'ai passé en premier:
+
+\lstinputlisting[style=customasmARM]{examples/bitcoin_miner/tmp1.lst}
+
+La division via la multiplication est utilisée ici, et la constante est 0x51EB851F.
+Je me suis écrit un petit calculateur pour programmeur\footnote{\url{https://github.com/DennisYurichev/progcalc}}.
+Et il est capable de calculer le modulo inverse.
+
+\begin{lstlisting}
+modinv32(0x51EB851F)
+Warning, result is not integer: 3.125000
+(unsigned) dec: 3 hex: 0x3 bin: 11
+\end{lstlisting}
+
+Cela signifie que l'instruction \INS{SMULL} en 0xACA0 divise le 3ème argument par 3.125.
+En fait, tout ce que la fonction \TT{modinv32()} de mon calculateur fait est ceci:
+
+\[
+\frac{1}{\frac{input}{2^{32}}} = \frac{2^{32}}{input}
+\]
+
+Ensuite il y a es décalages additionnels et maintenant nous voyons que le 3ème argument
+est simplement divisé par 50.
+Et ensuite il à nouveau multiplié par 50.
+Pourquoi?
+Ceci est un simple test, pour savoir si la valeur entrée est divisible par 50.
+Si la valeur de cette expression est non nulle, $x$ n'est pas divisible par 50:
+
+\[
+x-((\frac{x}{50}) \cdot 50)
+\]
+
+Ceci est en fait une manière simple de calculer le reste de la division.
+
+Et alors, si le reste est non nul, un message d'erreur est affiché.
+Donc cet utilitaire prend des fréquences comme 850, 900, 950, 1000, etc., mais pas 855 ou 911.
+
+C'est ça! Si vous faites quelque chose comme ça, soyez avertis que vous pouvez endommager
+votre carte, tout comme en cas d'overclocking d'autres éléments comme les \ac{CPU}s,
+\ac{GPU}s, etc.
+Si vous avez une carte Cointerra, faites ceci à votre propre risque!
+

--- a/examples/examples_FR.tex
+++ b/examples/examples_FR.tex
@@ -25,7 +25,7 @@
 %% TODO \input{examples/qr9/qr9_FR}
 %% TODO \input{examples/encrypted_DB1/main_FR}
 %% TODO \input{examples/bitcoin_miner/main_FR}
-%% TODO \input{examples/simple_exec_crypto/main_FR}
+\input{examples/simple_exec_crypto/main_FR}
 \input{examples/SAP/main}
 %% TODO \input{examples/oracle/main_FR}
 \input{examples/handcoding/main_FR}

--- a/examples/examples_FR.tex
+++ b/examples/examples_FR.tex
@@ -24,7 +24,7 @@
 \input{examples/dongles/main_FR}
 %% TODO \input{examples/qr9/qr9_FR}
 %% TODO \input{examples/encrypted_DB1/main_FR}
-%% TODO \input{examples/bitcoin_miner/main_FR}
+\input{examples/bitcoin_miner/main_FR}
 \input{examples/simple_exec_crypto/main_FR}
 \input{examples/SAP/main}
 %% TODO \input{examples/oracle/main_FR}

--- a/examples/simple_exec_crypto/main_EN.tex
+++ b/examples/simple_exec_crypto/main_EN.tex
@@ -95,7 +95,7 @@ FF byte is also very often occurred in negative displacements like these:
 8D 95 F8 5C FF FF                 lea     edx, [ebp-0A308h]
 \end{lstlisting}
 
-So far so good. Now we have to try various 16-byte keys, decrypt executable section and measure how often 00, FF ad 8B bytes are occurred.
+So far so good. Now we have to try various 16-byte keys, decrypt executable section and measure how often 00, FF and 8B bytes are occurred.
 Let's also keep in sight how PCBC decryption works:
 
 \begin{figure}[H]
@@ -162,7 +162,7 @@ for N in range(KEY_LEN):
     print sorted_stat[0]
 \end{lstlisting}
 
-(Source code can downloaded \href{https://github.com/DennisYurichev/RE-for-beginners/blob/master/examples/simple_exec_crypto/files/decrypt.py}{here}.)
+(Source code can be downloaded \href{https://github.com/DennisYurichev/RE-for-beginners/blob/master/examples/simple_exec_crypto/files/decrypt.py}{here}.)
 
 I run it and here is a key for which 00/FF/8B bytes presence in decrypted buffer is maximal:
 
@@ -243,14 +243,14 @@ for c in tmp:
 fout.close()
 \end{lstlisting}
 
-(Source code can downloaded \href{https://github.com/DennisYurichev/RE-for-beginners/blob/master/examples/simple_exec_crypto/files/decrypt2.py}{here}.)
+(Source code can be downloaded \href{https://github.com/DennisYurichev/RE-for-beginners/blob/master/examples/simple_exec_crypto/files/decrypt2.py}{here}.)
 
 Let's check resulting file:
 
 \lstinputlisting{examples/simple_exec_crypto/objdump_result.txt}
 
 Yes, this is seems correctly disassembled piece of x86 code.
-The whole dectyped file can be downloaded \href{https://github.com/DennisYurichev/RE-for-beginners/blob/master/examples/simple_exec_crypto/files/decrypted.bin}{here}.
+The whole decryped file can be downloaded \href{https://github.com/DennisYurichev/RE-for-beginners/blob/master/examples/simple_exec_crypto/files/decrypted.bin}{here}.
 
 In fact, this is text section from regedit.exe from Windows 7.
 But this example is based on a real case I encountered, so just executable is different (and key), algorithm is the same.

--- a/examples/simple_exec_crypto/main_FR.tex
+++ b/examples/simple_exec_crypto/main_FR.tex
@@ -1,0 +1,302 @@
+\mysection{Casser le simple exécutable cryptor}
+
+J'ai un fichier exécutable qui est chiffré par un chiffrement relativement simple.
+\href{https://github.com/DennisYurichev/RE-for-beginners/blob/master/examples/simple_exec_crypto/files/cipher.bin}{Il est ici}
+(seule la section exécutable est laissée ici).
+
+Tout d'abord, tout ce que fait la fonction de chiffrement, c'est d'ajouter l'index
+de la position dans le buffer à l'octet.
+Voici comment ça peut être implémenté en Python:
+
+\begin{lstlisting}[caption=Python script,style=custompy]
+#!/usr/bin/env python
+def e(i, k):
+    return chr ((ord(i)+k) % 256)
+
+def encrypt(buf):
+    return e(buf[0], 0)+ e(buf[1], 1)+ e(buf[2], 2) + e(buf[3], 3)+ e(buf[4], 4)+ e(buf[5], 5)+ e(buf[6], 6)+ e(buf[7], 7)+
+           e(buf[8], 8)+ e(buf[9], 9)+ e(buf[10], 10)+ e(buf[11], 11)+ e(buf[12], 12)+ e(buf[13], 13)+ e(buf[14], 14)+ e(buf[15], 15)
+\end{lstlisting}
+
+Ainsi, si vous chiffrez un buffer avec 16 zéros, vous obtiendrez \emph{0, 1, 2, 3 ... 12, 13, 14, 15}.
+
+\myindex{Propagating Cipher Block Chaining}
+La Propagating Cipher Block Chaining (PCBC) est aussi utilisée, voici comment elle
+fonctionne:
+
+\begin{figure}[H]
+\centering
+\myincludegraphics{examples/simple_exec_crypto/601px-PCBC_encryption.png}
+\caption{Chiffrement avec Propagating Cipher Block Chaining (l'image provient d'un article Wikipédia)}
+\end{figure}
+
+Le problème est qu'il est trop ennuyant de retrouver l'IV (Initialization Vector)
+à chaque fois.
+La force brute n'est pas une option, car l'IV est trop long (16 octets).
+Voyons s'il est possible de recouvrer l'IV pour un fichier binaire exécutable arbitraire?
+
+Essayons la simple analyse de fréquence.
+Ceci est du code exécutable 32-bit x86, donc collectons des statistiques sur les
+octets et les opcodes les plus fréquents.
+J'ai essayé le fichier géant oracle.exe d' Oracle RDBMS version 11.2 pour windows
+x86 et j'ai trouvé que l'octet le plus fréquent (pas de surprise) est zéro (~10\%).
+L'octet suivant le plus fréquent est (encore une fois, sans surprise) 0xFF (~5\%).
+Le suivant est 0x8B (~5\%).
+
+\myindex{x86!\Instructions!MOV}
+0x8B est l'opcode de \INS{MOV}, ceci est en effet l'une des instructions x86 les
+plus fréquentes.
+Maintenant, que dire de la popularité de l'octet zéro?
+Si le compilateur doit encoder une valeur plus grande que 127, il doit utiliser un
+déplacement 32-bit au lieu d'un de 8-bit, mais les grandes valeurs sont très rares,
+donc il est complété par des zéros.
+\myindex{x86!\Instructions!LEA}
+\myindex{x86!\Instructions!PUSH}
+\myindex{x86!\Instructions!CALL}
+C'est le cas au moins avec \INS{LEA}, \INS{MOV}, \INS{PUSH}, \INS{CALL}.
+
+Par exemple:
+
+\begin{lstlisting}[style=customasmx86]
+8D B0 28 01 00 00                 lea     esi, [eax+128h]
+8D BF 40 38 00 00                 lea     edi, [edi+3840h]
+\end{lstlisting}
+
+Les déplacements plus grand que 127 sont très fréquents, mais ils excèdent rarement
+0x10000 (en effet, des buffers mémoire/structures aussi grands sont aussi rares).
+
+Même chose avec \INS{MOV}, les grandes constantes sont rares, les plus utilisées sont
+0, 1, 10, 100, $2^n$, et ainsi de suite.
+Le compilateur doit compléter les petites constantes avec des zéros pour les encoder
+comme des valeurs 32-bit:
+
+\begin{lstlisting}[style=customasmx86]
+BF 02 00 00 00                    mov     edi, 2
+BF 01 00 00 00                    mov     edi, 1
+\end{lstlisting}
+
+Maintenant parlons des octets 00 et FF combinés: les sauts (conditionnels inclus)
+et appels peuvent transférer le flux d'exécution en avant ou en arrière, mais très
+souvent, dans les limites du module exécutable courant.
+Si c'est en avant, le déplacement n'est pas très grand et il y a des zéros ajoutés.
+Si c'est en arrière, le déplacement est représenté par une valeur négative, donc
+complétée par des octets FF.
+Par exemple, transfert du flux d'exécution en avant:
+
+\begin{lstlisting}[style=customasmx86]
+E8 43 0C 00 00                    call    _function1
+E8 5C 00 00 00                    call    _function2
+0F 84 F0 0A 00 00                 jz      loc_4F09A0
+0F 84 EB 00 00 00                 jz      loc_4EFBB8
+\end{lstlisting}
+
+En arrière:
+
+\begin{lstlisting}[style=customasmx86]
+E8 79 0C FE FF                    call    _function1
+E8 F4 16 FF FF                    call    _function2
+0F 84 F8 FB FF FF                 jz      loc_8212BC
+0F 84 06 FD FF FF                 jz      loc_FF1E7D
+\end{lstlisting}
+
+L'octet FF se rencontre aussi très souvent dans des déplacements négatifs, comme
+ceux-ci:
+
+\begin{lstlisting}[style=customasmx86]
+8D 85 1E FF FF FF                 lea     eax, [ebp-0E2h]
+8D 95 F8 5C FF FF                 lea     edx, [ebp-0A308h]
+\end{lstlisting}
+
+Jusqu'ici, tout va bien. Maintenant nous devons essayer diverses clefs 16-octet, déchiffrer
+la section exécutable et mesurer les occurences des octets 00, FF et 8B.
+Gardons en vue la façon dont le déchiffrement PCBC fonctionne:
+
+\begin{figure}[H]
+\centering
+\myincludegraphics{examples/simple_exec_crypto/640px-PCBC_decryption.png}
+\caption{Propagating Cipher Block Chaining decryption (l'image provient d'un article Wikipédia)}
+\end{figure}
+
+La bonne nouvelle est que nous n'avons pas vraiment besoin de déchiffrer l'ensemble
+des données, mais seulement slice par slice, ceci est exactement comment j'ai procédé
+dans mon exemple précédent: \myref{XOR_mask_2}.
+
+Maintenant j'essaye tous les octets possible (0..255) pour chaque octet dans la clef
+et je prends l'octet produisant le plus grande nombre d'octets 00/FF/8B dans le slice
+déchiffré:
+
+\begin{lstlisting}[style=custompy]
+#!/usr/bin/env python
+import sys, hexdump, array, string, operator
+
+KEY_LEN=16
+
+def chunks(l, n):
+    # split n by l-byte chunks
+    # https://stackoverflow.com/q/312443
+    n = max(1, n)
+    return [l[i:i + n] for i in range(0, len(l), n)]
+
+def read_file(fname):
+    file=open(fname, mode='rb')
+    content=file.read()
+    file.close()
+    return content
+
+def decrypt_byte (c, key):
+    return chr((ord(c)-key) % 256)
+
+def XOR_PCBC_step (IV, buf, k):
+    prev=IV
+    rt=""
+    for c in buf:
+	new_c=decrypt_byte(c, k)
+        plain=chr(ord(new_c)^ord(prev))
+	prev=chr(ord(c)^ord(plain))
+	rt=rt+plain
+    return rt
+
+each_Nth_byte=[""]*KEY_LEN
+
+content=read_file(sys.argv[1])
+# split input by 16-byte chunks:
+all_chunks=chunks(content, KEY_LEN)
+for c in all_chunks:
+    for i in range(KEY_LEN):
+        each_Nth_byte[i]=each_Nth_byte[i] + c[i]
+
+# try each byte of key
+for N in range(KEY_LEN):
+    print "N=", N
+    stat={}
+    for i in range(256):
+        tmp_key=chr(i)
+	tmp=XOR_PCBC_step(tmp_key,each_Nth_byte[N], N)
+        # count 0, FFs and 8Bs in decrypted buffer:
+	important_bytes=tmp.count('\x00')+tmp.count('\xFF')+tmp.count('\x8B')
+	stat[i]=important_bytes
+    sorted_stat = sorted(stat.iteritems(), key=operator.itemgetter(1), reverse=True)
+    print sorted_stat[0]
+\end{lstlisting}
+
+(Le code source peut être téléchargé
+\href{https://github.com/DennisYurichev/RE-for-beginners/blob/master/examples/simple_exec_crypto/files/decrypt.py}{ici}.)
+
+Je le lance et voici une clef pour laquelle le nombre d'octets 00/FF/8B dans le buffer
+déchiffré est maximum:
+
+\begin{lstlisting}
+N= 0
+(147, 1224)
+N= 1
+(94, 1327)
+N= 2
+(252, 1223)
+N= 3
+(218, 1266)
+N= 4
+(38, 1209)
+N= 5
+(192, 1378)
+N= 6
+(199, 1204)
+N= 7
+(213, 1332)
+N= 8
+(225, 1251)
+N= 9
+(112, 1223)
+N= 10
+(143, 1177)
+N= 11
+(108, 1286)
+N= 12
+(10, 1164)
+N= 13
+(3, 1271)
+N= 14
+(128, 1253)
+N= 15
+(232, 1330)
+\end{lstlisting}
+
+Écrivons un utilitaire de déchiffrement avec la clef obtenue:
+
+\begin{lstlisting}[style=custompy]
+#!/usr/bin/env python
+import sys, hexdump, array
+
+def xor_strings(s,t):
+    # \verb|https://en.wikipedia.org/wiki/XOR_cipher#Example_implementation|
+    """xor two strings together"""
+    return "".join(chr(ord(a)^ord(b)) for a,b in zip(s,t))
+
+IV=array.array('B', [147, 94, 252, 218, 38, 192, 199, 213, 225, 112, 143, 108, 10, 3, 128, 232]).tostring()
+
+def chunks(l, n):
+    n = max(1, n)
+    return [l[i:i + n] for i in range(0, len(l), n)]
+
+def read_file(fname):
+    file=open(fname, mode='rb')
+    content=file.read()
+    file.close()
+    return content
+
+def decrypt_byte(i, k):
+    return chr ((ord(i)-k) % 256)
+
+def decrypt(buf):
+    return "".join(decrypt_byte(buf[i], i) for i in range(16))
+
+fout=open(sys.argv[2], mode='wb')
+
+prev=IV
+content=read_file(sys.argv[1])
+tmp=chunks(content, 16)
+for c in tmp:
+    new_c=decrypt(c)
+    p=xor_strings (new_c, prev)
+    prev=xor_strings(c, p)
+    fout.write(p)
+fout.close()
+\end{lstlisting}
+
+(Le code source peut être téléchargé
+\href{https://github.com/DennisYurichev/RE-for-beginners/blob/master/examples/simple_exec_crypto/files/decrypt2.py}
+{ici}.)
+
+Vérifions le fichier résultant:
+
+\lstinputlisting{examples/simple_exec_crypto/objdump_result.txt}
+
+Oui, ceci semble être un morceau correctement désassemblé de code x86.
+Le fichier déchiffré entier peut être téléchargé
+\href{https://github.com/DennisYurichev/RE-for-beginners/blob/master/examples/simple_exec_crypto/files/decrypted.bin}{ici}.
+
+En fait, ceci est la section text du regedit.exe de Windows 7.
+Mais cet exemple est basé sur un cas réel que j'ai rencontré, seul l'exécutable est
+différent (et la clef), l'algorithme est le même.
+
+\subsection{Autres idées à prendre en considération}
+
+Et si j'avais échoué avec cette simple analyse des fréquences?
+Il y a d'autres idées sur la façon de mesurer l'exactitude de code x86 déchiffré/décompressé:
+
+\begin{itemize}
+
+\item Les compilateurs modernes alignent les fonctions sur une limite de 0x10.
+Donc l'espace libre avant est rempli avec de NOPs (0x90) ou d'autres instructions
+avec des opcodes connus: \myref{sec:npad}.
+
+\item Peut-être que le pattern le plus fréquent dans tout langage d'assemblage est
+l'appel de fonction:\\
+\TT{PUSH chain / CALL / ADD ESP, X}.
+Cette séquence peut facilement être détectée et trouvée.
+J'ai même collecté des statistiques sur le nombre moyen d'arguments des fonctions: \myref{args_stat}.
+(Ainsi, ceci est la longueur moyenne d'une chaîne PUSH.)
+
+\end{itemize}
+
+En savoir plus sur le code désassemblé incorrectement/correctement: \myref{ISA_detect}.
+


### PR DESCRIPTION
Two examples chapter parts translated to French.
Minor English typos.