### PR TITLE
Fixed reference in listing 1.265

### DIFF
--- a/patterns/14_bitfields/1_check/check3.asm
+++ b/patterns/14_bitfields/1_check/check3.asm
@@ -1,4 +1,4 @@
-loc_C01EF6B4:       ; CODE XREF: do\_filp\_open+4F
+loc_C01EF684:       ; CODE XREF: do\_filp\_open+4F
                 test    bl, 40h         ; O\_CREAT
                 jnz     loc_C01EF810
                 mov     edi, ebx


### PR DESCRIPTION
Listing 1.265 referenced loc_C01EF684 while the actual label
in listing 1.266 was loc_C01EF6B4.